### PR TITLE
[Reviewer: Andy] Reset event state when we restart a service

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -706,6 +706,12 @@ static void handle_action(Event_T E, Action_T A) {
     if (s->mode == MODE_PASSIVE && (A->id == ACTION_START || A->id == ACTION_STOP  || A->id == ACTION_RESTART))
       return;
 
+    if ((A->id == ACTION_START) || (A->id == ACTION_STOP) || (A->id == ACTION_RESTART)) {
+      // About to restart this service, so reset all its values.
+      E->state_map = 0;
+      E->state = STATE_INIT;
+    }
+
     control_service(s->name, A->id);
   }
 }


### PR DESCRIPTION
This makes grace periods behave properly. Tested by making clearwater-nginx listen on the wrong port, and making sure thre were always three failed polls in the logs between restarts (rather than three failed polls, then a restart on every poll).

Once we take https://github.com/ClearwaterCore/monit/commit/c358150f44ac14c5066a9fe79536dc45739ba2d7 and install this version of monit instead of the main Ubuntu version, this will fix https://github.com/Metaswitch/chef/issues/28.