### PR TITLE
[Reviewer: Matt] Change upstart config so monit doesn't daemonize

### DIFF
--- a/debian/clearwater-monit.upstart
+++ b/debian/clearwater-monit.upstart
@@ -9,7 +9,6 @@ description "Monit service manager"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
-expect daemon
 respawn
 
 limit core unlimited unlimited
@@ -24,7 +23,7 @@ script
     . /etc/default/clearwater-monit
     [ "$START" = "yes" ] || { stop; exit 0; }
 
-    exec /usr/bin/monit -c /etc/monit/monitrc $MONIT_OPTS    
+    exec /usr/bin/monit -I -c /etc/monit/monitrc $MONIT_OPTS    
 end script
 
 pre-stop exec /usr/bin/monit -c /etc/monit/monitrc quit


### PR DESCRIPTION
Upstart gets very confused if:
* it starts monit, expecting it to daemonize
* the monit process gets killed (e.g. by SIGHUP) before daemonizing

To close this window, I've passed the -I flag to monit so it doesn't daemonize (this flag is documented specifically as being for init purposes).

Fixes #18. I've verified this fix by adding a `sleep(10)` at the start of the main function, which meant clearwater-infrastructure always SIGHUPed monit before it daemonized or registered signal handlers. Before this fix, I reproed #18 on every boot, and it went away after this fix.