### PR TITLE
Reviewer AMC: Reduce catchall timeout for monit check programs from 10 minutes to 1…

### DIFF
--- a/src/monit.h
+++ b/src/monit.h
@@ -124,7 +124,7 @@
 
 #define START_DELAY        0
 #define EXEC_TIMEOUT       30
-#define PROGRAM_TIMEOUT    600
+#define PROGRAM_TIMEOUT    60
 
 #define START_HTTP         1
 #define STOP_HTTP          2


### PR DESCRIPTION
… minute

This allows monit to timeout those instances where poll scripts hang for some reason (e.g. system resource exhaustion or kernel bugs) far sooner than at present (after 1 minute instead of 10) and therefore shutdown their potentially misbehaving component after 2 minutes rather than 20.

Tested on a combined Sprout+Homestead box by hacking one of the poll scripts so that it took 65 seconds to complete (monit killed the script after 60 seconds and restarted the component after 2 iterations, as expected) and, after restoring the hacked poll script, leaving overnight and checking that no poll scripts had subsequently been unexpectedly timed out.