### PR TITLE
[Reviewer: Adam] Add support for the centos build

### DIFF
--- a/clearwater-monit.root/usr/share/clearwater/clearwater-monit/install/clearwater-monit.postinst
+++ b/clearwater-monit.root/usr/share/clearwater/clearwater-monit/install/clearwater-monit.postinst
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# Setup logfile permissions:
+touch /var/log/monit.log
+chmod 640 /var/log/monit.log
+chown root:adm /var/log/monit.log
+chmod 600 /etc/monit/monitrc
+
+# Add monit to /etc/aliases:
+if [ -f /etc/aliases ] || [ -L /etc/aliases ]
+then
+  if ! grep -qi '^monit[[:space:]]*:' /etc/aliases
+  then
+    echo "monit: root" >> /etc/aliases
+    test -x /usr/bin/newaliases && newaliases || :
+  fi
+fi
+
+# Ensure monit is stopped before starting it under upstart control (work-around
+# for package script race conditions when upgrading monit -> clearwater-monit).
+if (ps -C monit > /dev/null); then
+  # Stop monit directly to avoid a race where service scripts can be removed 
+  # before the stop operation is initiated.
+  monit quit || true
+
+  # Ensure that monit is really gone before attempting to start via upstart. A
+  # race was observed here that also needed to be handled.
+  printf "Waiting for Monit to stop\n"
+  cnt=0
+  while (ps -C monit > /dev/null); do
+    sleep 1
+    printf "."
+    cnt=`expr $cnt + 1`
+    if [ $cnt -gt 120 ]; then
+	  printf "*** ERROR: unable to stop Monit\n"
+	  exit 1
+    fi
+  done
+
+  # Finally allow upstart to take control of monit safely (it will not take 
+  # ownership of a process not started under its control).
+  service clearwater-monit start || true
+fi
+
+# Remove all monit configuration files that are left behind when apt uninstalls
+# the old monit during an upgrade to clearwater-monit.
+if [ -f /etc/default/monit ]
+then
+   rm /etc/default/monit
+fi
+
+if [ -f /etc/init.d/monit ]
+then
+   rm /etc/init.d/monit
+fi
+
+if [ -f /etc/logrotate.d/monit ]
+then 
+  rm /etc/logrotate.d/monit
+fi
+
+if [ -f /etc/pam.d/monit ]
+then
+  rm /etc/pam.d/monit
+fi

--- a/clearwater.mk
+++ b/clearwater.mk
@@ -1,11 +1,16 @@
-DEB_COMPONENT := clearwater-monit
-DEB_MAJOR_VERSION := 5.8${DEB_VERSION_QUALIFIER}
-DEB_NAMES := clearwater-monit
+PKG_COMPONENT := clearwater-monit
+PKG_MAJOR_VERSION := 5.8.1
+PKG_NAMES := clearwater-monit
 
 include build-infra/cw-deb.mk
+include build-infra/cw-rpm.mk
+
+.PHONY: configure
+configure:
+	./bootstrap && ./configure
 
 .PHONY: deb-build-monit
-deb-build-monit:
+deb-build-monit: configure
 	echo -e "${DEB_COMPONENT} (${DEB_MAJOR_VERSION}-${DEB_MINOR_VERSION}) unstable; urgency=low\n" >debian/changelog
 	echo -e "  * build from revision $$(git rev-parse HEAD)\n" >>debian/changelog
 	echo -e " -- $(CW_SIGNER_REAL) <$(CW_SIGNER)>  $$(date -R)\n" >>debian/changelog
@@ -13,3 +18,7 @@ deb-build-monit:
 
 .PHONY: deb
 deb: deb-build-monit deb-move
+
+.PHONY: rpm
+rpm: configure rpm-only
+

--- a/debian/clearwater-monit.install
+++ b/debian/clearwater-monit.install
@@ -1,1 +1,2 @@
 debian/monitrc etc/monit/
+clearwater-monit.root/* /

--- a/debian/clearwater-monit.postinst
+++ b/debian/clearwater-monit.postinst
@@ -4,69 +4,7 @@ set -e
 
 case "$1" in
   configure)
-    # Setup logfile permissions:
-    touch /var/log/monit.log
-    chmod 640 /var/log/monit.log
-    chown root:adm /var/log/monit.log
-
-    # Add monit to /etc/aliases:
-    if [ -f /etc/aliases ] || [ -L /etc/aliases ]
-    then
-      if ! grep -qi '^monit[[:space:]]*:' /etc/aliases
-      then
-        echo "monit: root" >> /etc/aliases
-        test -x /usr/bin/newaliases && newaliases || :
-      fi
-    fi
-
-    # Ensure monit is stopped before starting it under upstart control (work-around
-    # for package script race conditions when upgrading monit -> clearwater-monit).
-    if (ps -C monit > /dev/null); then
-      # Stop monit directly to avoid a race where service scripts can be removed 
-      # before the stop operation is initiated.
-      monit quit || true
-
-      # Ensure that monit is really gone before attempting to start via upstart. A
-      # race was observed here that also needed to be handled.
-      printf "Waiting for Monit to stop\n"
-      cnt=0
-      while (ps -C monit > /dev/null); do
-        sleep 1
-        printf "."
-        cnt=`expr $cnt + 1`
-        if [ $cnt -gt 120 ]; then
-	  printf "*** ERROR: unable to stop Monit\n"
-	  exit 1
-        fi
-      done
-
-      # Finally allow upstart to take control of monit safely (it will not take 
-      # ownership of a process not started under its control).
-      service clearwater-monit start || true
-    fi
-
-    # Remove all monit configuration files that are left behind when apt uninstalls
-    # the old monit during an upgrade to clearwater-monit.
-    if [ -f /etc/default/monit ]
-    then
-       rm /etc/default/monit
-    fi
-
-    if [ -f /etc/init.d/monit ]
-    then
-       rm /etc/init.d/monit
-       update-rc.d monit remove
-    fi
-
-    if [ -f /etc/logrotate.d/monit ]
-    then 
-      rm /etc/logrotate.d/monit
-    fi
-
-    if [ -f /etc/pam.d/monit ]
-    then
-      rm /etc/pam.d/monit
-    fi
+    /usr/share/clearwater/clearwater-monit/install/clearwater-monit.postinst
     ;;
   abort-upgrade|abort-remove|abort-deconfigure)
     ;;

--- a/debian/clearwater-monit.service
+++ b/debian/clearwater-monit.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Clearwater-monit service manager
+
+[Service]
+ExecStartPre=/usr/share/clearwater/bin/issue_alarm.py "systemd" "4500.6"
+ExecStart=/usr/bin/monit -I -c /etc/monit/monitrc ; 
+Restart=on-failure
+RestartSec=5s
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/clearwater-monit.service
+++ b/debian/clearwater-monit.service
@@ -1,3 +1,5 @@
+# systemd control file for clearwater-monit
+
 [Unit]
 Description=Clearwater-monit service manager
 

--- a/rpm/.gitignore
+++ b/rpm/.gitignore
@@ -1,0 +1,7 @@
+BUILD/
+BUILDROOT/
+RPMS/
+SOURCES/
+SPECS/
+SRPMS/
+changelog

--- a/rpm/clearwater-monit.spec
+++ b/rpm/clearwater-monit.spec
@@ -1,0 +1,37 @@
+Name: clearwater-monit
+Summary: Process monitor and restart utility
+BuildRequires: flex bison openssl-devel pam-devel
+
+%include %{rootdir}/build-infra/cw-rpm.spec.inc
+
+%description
+Monit is a utility for managing and monitoring processes,
+files, directories and filesystems on a Unix system. Monit conducts
+automatic maintenance and repair and can execute meaningful causal
+actions in error situations.
+
+%install
+. %{rootdir}/build-infra/cw-rpm-utils clearwater-monit %{rootdir} %{buildroot}
+setup_buildroot
+install_to_buildroot < %{rootdir}/debian/clearwater-monit.install
+dirs_to_buildroot < %{rootdir}/debian/clearwater-monit.dirs
+copy_to_buildroot debian/clearwater-monit.service /etc/systemd/system
+copy_to_buildroot debian/clearwater-monit.logrotate /etc/logrotate.d clearwater-monit
+copy_to_buildroot debian/clearwater-monit.default /etc/default clearwater-monit
+build_files_list > clearwater-monit.files
+
+%post
+if [ "$1" == 1 ] ; then
+  /usr/share/clearwater/clearwater-monit/install/clearwater-monit.postinst
+fi
+systemctl enable clearwater-monit
+systemctl start clearwater-monit
+
+%preun
+# Uninstall, not upgrade
+if [ "$1" == 0 ] ; then
+  systemctl stop clearwater-monit
+  systemctl disable clearwater-monit
+fi
+
+%files -f clearwater-monit.files


### PR DESCRIPTION
Adam, can you please review this change to add support for running monit on centos.

This PR doesn't cover any changes to let the monit scripts run on centos.