### PR TITLE
[Reviewer: Richard] Fixes for 5.18

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -308,6 +308,11 @@ static void _handleAction(Event_T E, Action_T A) {
                                 E->source->nstart++;
                         if (E->source->mode == Monitor_Passive && (A->id == Action_Start || A->id == Action_Stop  || A->id == Action_Restart))
                                 return;
+                        if ((A->id == Action_Start) || (A->id == Action_Stop) || (A->id == Action_Restart)) {
+                                // About to restart this service, so reset all its values.
+                                E->state = State_Init;
+                                memset(&(E->state_map), State_Init, sizeof(E->state_map));
+                        }
                         control_service(E->source->name, A->id);
                 }
         }


### PR DESCRIPTION
This is the interesting PR for monit (as opposed to https://github.com/Metaswitch/clearwater-monit/pull/32). This makes some logs more helpful, correctly un/monitors programs when the process they're dependent on restarts, and resets any failure counts when a process restarts