### PR TITLE
[Reviewer: Ellie] Have process restart set to 'always', to cover when PID is killed

### DIFF
--- a/debian/clearwater-monit.service
+++ b/debian/clearwater-monit.service
@@ -6,7 +6,7 @@ Description=Clearwater-monit service manager
 [Service]
 ExecStartPre=/usr/share/clearwater/bin/issue-alarm "systemd" "4500.6"
 ExecStart=/usr/bin/monit -I -c /etc/monit/monitrc
-Restart=on-failure
+Restart=always
 RestartSec=5s
 LimitCORE=infinity
 


### PR DESCRIPTION
This means the process comes back when stopped with `sudo kill <PID>`.
Unlike we worried though, the process is not then unstoppable, as systemd treats any command issued through it as special (See the Restart= section in https://www.freedesktop.org/software/systemd/man/systemd.service.html ). 
As such, running `sudo service <blah> stop` still stops the process until it is manually started again.

I have tested this with Monit only at the moment, and will link this PR in the others that have a similar change.