### PR TITLE
[Reviewer: Graeme] Disable tables and colours by default

### DIFF
--- a/src/monit.c
+++ b/src/monit.c
@@ -623,6 +623,9 @@ static void handle_options(int argc, char **argv) {
                 {"version",     no_argument,            NULL,   'V'},
                 {0}
         };
+
+        Run.flags |= Run_Batch;
+        
         while ((opt = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1)
 #else
                 while ((opt = getopt(argc, argv, shortopts)) != -1)
@@ -725,7 +728,7 @@ static void handle_options(int argc, char **argv) {
                                 }
                                 case 'B':
                                 {
-                                        Run.flags |= Run_Batch;
+                                        Run.flags &= ~Run_Batch;
                                         break;
                                 }
                                 case '?':
@@ -804,7 +807,7 @@ static void help() {
                " -I            Do not run in background (needed for run from init)\n"
                " --id          Print Monit's unique ID\n"
                " --resetid     Reset Monit's unique ID. Use with caution\n"
-               " -B            Batch command line mode (do not output tables or colors)\n"
+               " -B            Turn off batch command line mode (output tables and colors)\n"
                " -t            Run syntax check for the control file\n"
                " -v            Verbose mode, work noisy (diagnostic output)\n"
                " -vv           Very verbose mode, same as -v plus log stacktrace on error\n"

--- a/src/monit.c
+++ b/src/monit.c
@@ -807,7 +807,7 @@ static void help() {
                " -I            Do not run in background (needed for run from init)\n"
                " --id          Print Monit's unique ID\n"
                " --resetid     Reset Monit's unique ID. Use with caution\n"
-               " -B            Turn off batch command line mode (output tables and colors)\n"
+               " -B            Turn on colour display mode (output tables and colors)\n"
                " -t            Run syntax check for the control file\n"
                " -v            Verbose mode, work noisy (diagnostic output)\n"
                " -vv           Very verbose mode, same as -v plus log stacktrace on error\n"

--- a/src/monit.c
+++ b/src/monit.c
@@ -624,6 +624,9 @@ static void handle_options(int argc, char **argv) {
                 {0}
         };
 
+        // We disable the colours and tables on the monit summary/status calls
+        // as we can't rely on them displaying correctly. You can turn them on
+        // by adding the -B flag
         Run.flags |= Run_Batch;
         
         while ((opt = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1)


### PR DESCRIPTION
This PR disables the fancy new tables and colours by default. You can still get the tables/colours by running sudo monit summary -B (I've simply flipped what the meaning of the -B flag is).