### PR TITLE
[Reviewer: Ellie] Alter upstart script to correctly raise alarm on Monit death

### DIFF
--- a/debian/clearwater-monit.upstart
+++ b/debian/clearwater-monit.upstart
@@ -25,9 +25,9 @@ script
     . /etc/default/clearwater-monit
     [ "$START" = "yes" ] || { stop; exit 0; }
 
-    exec /usr/bin/monit -I -c /etc/monit/monitrc $MONIT_OPTS    
+    /usr/share/clearwater/bin/issue-alarm "upstart" "4500.6"
 
-    exec /usr/share/clearwater/bin/issue-alarm "upstart" "4500.6"
+    exec /usr/bin/monit -I -c /etc/monit/monitrc $MONIT_OPTS
 end script
 
 pre-stop exec /usr/bin/monit -c /etc/monit/monitrc quit


### PR DESCRIPTION
The exec ensures we buck out of the script section when running monit, and putting the alarm call above this means we do correctly raise the alarm when Monit is restarted.

Tested on a Sprout node, and killing Monit triggers the restart, and the alarm is seen in a tcpdump.