### PR TITLE
[Reviewer: Ellie] Add log containing pid and errno from findProcess

### DIFF
--- a/src/process/ProcessTree.c
+++ b/src/process/ProcessTree.c
@@ -316,6 +316,7 @@ pid_t ProcessTree_findProcess(Service_T s) {
         if (s->inf->priv.process.pid > 0) {
                 errno = 0;
                 if (getpgid(s->inf->priv.process.pid) > -1 || errno == EPERM)
+                        DEBUG("getpid returned >-1 for pid %d, or errno==EPERM; errno was %d", s->inf->priv.process.pid, errno);
                         return s->inf->priv.process.pid;
         }
         // If the cached PID is not running, scan for the process again

--- a/src/process/ProcessTree.c
+++ b/src/process/ProcessTree.c
@@ -317,9 +317,9 @@ pid_t ProcessTree_findProcess(Service_T s) {
                 errno = 0;
                 if (getpgid(s->inf->priv.process.pid) > -1 || errno == EPERM) {
                         if (errno == EPERM) {
-                                LogError("getpid returned errno == EPERM");
+                                LogError("getpgid returned errno == EPERM");
                         }
-                        DEBUG("getpid returned > -1 for pid %d; errno was %d", s->inf->priv.process.pid, errno);
+                        DEBUG("getpgid returned > -1 for pid %d; errno was %d", s->inf->priv.process.pid, errno);
                         return s->inf->priv.process.pid;
                 }
         }

--- a/src/process/ProcessTree.c
+++ b/src/process/ProcessTree.c
@@ -315,9 +315,13 @@ pid_t ProcessTree_findProcess(Service_T s) {
         // Test the cached PID first
         if (s->inf->priv.process.pid > 0) {
                 errno = 0;
-                if (getpgid(s->inf->priv.process.pid) > -1 || errno == EPERM)
-                        DEBUG("getpid returned >-1 for pid %d, or errno==EPERM; errno was %d", s->inf->priv.process.pid, errno);
+                if (getpgid(s->inf->priv.process.pid) > -1 || errno == EPERM) {
+                        if (errno == EPERM) {
+                                LogError("getpid returned errno == EPERM");
+                        }
+                        DEBUG("getpid returned > -1 for pid %d; errno was %d", s->inf->priv.process.pid, errno);
                         return s->inf->priv.process.pid;
+                }
         }
         // If the cached PID is not running, scan for the process again
         if (s->matchlist) {


### PR DESCRIPTION
Added a log to potentially help debugging an issue we saw on the staging system.

The queue manager process had died/been killed, and monit was not restarting it. 
There was still a PID file, with a number in it, but no process with that ID.

Monit logs were repeatedly printing out the error log from https://github.com/Metaswitch/clearwater-monit/blob/master/src/validate.c#L1133 

Hopefully this log will help to debug the issue further if it is seen again.