### PR TITLE
[Reviewer: Richard] Allow 'service clearwater-monit reload' to work on systemd

### DIFF
--- a/debian/clearwater-monit.service
+++ b/debian/clearwater-monit.service
@@ -6,6 +6,7 @@ Description=Clearwater-monit service manager
 [Service]
 ExecStartPre=/usr/share/clearwater/bin/issue-alarm "systemd" "4500.6"
 ExecStart=/usr/bin/monit -I -c /etc/monit/monitrc
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5s
 LimitCORE=infinity


### PR DESCRIPTION
Tested by running `service clearwater-monit reload` and checking that new files in /etc/monit/conf.d got picked up.