### PR TITLE
[Reviewer: Ellie] Do not use cached PID for process checks

### DIFF
--- a/src/process/ProcessTree.c
+++ b/src/process/ProcessTree.c
@@ -312,6 +312,11 @@ time_t ProcessTree_getProcessUptime(pid_t pid) {
 
 pid_t ProcessTree_findProcess(Service_T s) {
         ASSERT(s);
+        /* Monit never checks if the cached PID is valid while it thinks the process is running.
+           If our process dies, and another takes it's place with the same PID, we fall into
+           a condition where we never attempt to restart the process. To avoid this, just
+           check the pidfile every cycle
+
         // Test the cached PID first
         if (s->inf->priv.process.pid > 0) {
                 errno = 0;
@@ -322,7 +327,8 @@ pid_t ProcessTree_findProcess(Service_T s) {
                         DEBUG("getpgid returned > -1 for pid %d; errno was %d", s->inf->priv.process.pid, errno);
                         return s->inf->priv.process.pid;
                 }
-        }
+        }*/
+
         // If the cached PID is not running, scan for the process again
         if (s->matchlist) {
                 // Update the process tree including command line

--- a/src/validate.c
+++ b/src/validate.c
@@ -1132,6 +1132,9 @@ State_Type check_process(Service_T s) {
                 } else {
                         LogError("'%s' failed to get service data\n", s->name);
                         rv = State_Failed;
+                        // We may have fallen into this state from a window condition where our PID was overtaken by a different process
+                        // To ensure we re-check our pidfile, and take appropriate action, we clear the cached pid.
+                        s->inf->priv.process.pid = 0;
                 }
         }
         for (Port_T pp = s->portlist; pp; pp = pp->next) {

--- a/src/validate.c
+++ b/src/validate.c
@@ -1132,9 +1132,6 @@ State_Type check_process(Service_T s) {
                 } else {
                         LogError("'%s' failed to get service data\n", s->name);
                         rv = State_Failed;
-                        // We may have fallen into this state from a window condition where our PID was overtaken by a different process
-                        // To ensure we re-check our pidfile, and take appropriate action, we clear the cached pid.
-                        s->inf->priv.process.pid = 0;
                 }
         }
         for (Port_T pp = s->portlist; pp; pp = pp->next) {


### PR DESCRIPTION
As described in https://github.com/Metaswitch/sprout/issues/1326, there is the potential for a rare window condition that can lead to our processes never being restarted.
The logic follows:

* Monit reads the given pidfile, and caches the pid value. 
* On each cycle of process checks, monit attempts to get the parent id of the cached pid, to check that the process is live. If this passes it returns
* If this test fails, Monit then re-checks the pidfile, looking for a new value

In the case where our process dies, and another process starts with the same pid, all within a single monit cycle, monit checks the cached pid, and finds a running process. This causes the process test to pass, and we never attempt to restart. 
It does not matter if the pidfile is changed or removed, if Monit has already locked onto the new process carrying the same pid.

This error condition can be forced by first setting the pidfile value to match a different running process, and then killing the original process. i.e. replace sprout.pid with the value in chronos.pid, and kill the sprout process.

### Fix

To resolve this, we simply stop monit from checking the cached pid. This means that on every cycle, monit will read the pid from the pidfile, and test that it is a running process.

Combined with this, the various process init.d scripts are enhanced to remove the process pidfile if they fail to abort the process by a name+pidfile match. This will allow monit to notice the process has died, and begin restarting the process accordingly.


### Considerations

This introduces a read from disk for every monitored process, once a monit poll cycle (10s). We do not believe that this will significantly impact performance, but we should verify this assumption in system testing.

