### PR TITLE
[Reviewer: Adam] Add WaitParent state

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -312,7 +312,7 @@ static boolean_t _doStop(Service_T s, boolean_t unmonitor) {
                 Util_monitorUnset(s);
         } else {
                 Util_resetInfo(s);
-                s->monitor = Monitor_Init | (s->monitor & Monitor_WaitParent);
+                s->monitor = Monitor_Init;
         }
         return rv;
 }

--- a/src/control.c
+++ b/src/control.c
@@ -312,7 +312,7 @@ static boolean_t _doStop(Service_T s, boolean_t unmonitor) {
                 Util_monitorUnset(s);
         } else {
                 Util_resetInfo(s);
-                s->monitor = Monitor_Init;
+                s->monitor = Monitor_Init | (s->monitor & Monitor_WaitParent);
         }
         return rv;
 }
@@ -398,9 +398,15 @@ static boolean_t _doDepend(Service_T s, Action_Type action, boolean_t unmonitor)
                                                 rv = false;
                                         } else {
                                                 // Stop this service only if all children stopped
-                                                if (action == Action_Stop && child->monitor != Monitor_Not) {
-                                                        if (! _doStop(child, unmonitor))
+                                                if ((action == Action_Stop) && (child->monitor != Monitor_Not)) {
+                                                        if (_doStop(child, unmonitor)) {
+                                                                // If we're still monitoring, set the flag to say we're waiting on our parent.
+                                                                if (!unmonitor) {
+                                                                        child->monitor |= Monitor_WaitParent;
+                                                                }
+                                                        } else {
                                                                 rv = false;
+                                                        }
                                                 } else if (action == Action_Unmonitor) {
                                                         _doUnmonitor(child);
                                                 }
@@ -469,15 +475,13 @@ boolean_t control_service(const char *S, Action_Type A) {
 
                 case Action_Restart:
                         LogInfo("'%s' trying to restart\n", s->name);
-                        // Restart this service. Try to unmonitor/stop any dependent services,
-                        // but continue the restart even if it fails.
-                        _doDepend(s, Action_Unmonitor, false);
+                        // Restart this service. Try to stop any dependent services, and make them
+                        // wait for their parent, but continue the restart even if it fails.
                         _doDepend(s, Action_Stop, false);
                         if (s->restart) {
                                 if ((rv = _doRestart(s))) {
                                         // Start children only if we successfully restarted
                                         _doDepend(s, Action_Start, false);
-                                        _doDepend(s, Action_Monitor, false);
                                 }
                         } else {
                                 if (_doStop(s, false)) {
@@ -485,7 +489,6 @@ boolean_t control_service(const char *S, Action_Type A) {
                                         if ((rv = _doStart(s))) {
                                                 // Start children only if we successfully started
                                                 _doDepend(s, Action_Start, false);
-                                                _doDepend(s, Action_Monitor, false);
                                         }
                                         else {
                                                 LogError("'%s' failed to start successfully\n", s->name);

--- a/src/http/cervlet.c
+++ b/src/http/cervlet.c
@@ -2407,7 +2407,7 @@ static char *get_monitoring_status(Output_Type type, Service_T s, char *buf, int
 static char *get_service_status(Output_Type type, Service_T s, char *buf, int buflen) {
         ASSERT(s);
         ASSERT(buf);
-        if ((s->monitor == Monitor_Not) || (s->monitor & Monitor_Init)) {
+        if (s->monitor == Monitor_Not || s->monitor & Monitor_Init) {
                 get_monitoring_status(type, s, buf, buflen);
         } else if (s->error == 0) {
                 if (type == HTML)

--- a/src/http/cervlet.c
+++ b/src/http/cervlet.c
@@ -2384,6 +2384,11 @@ static char *get_monitoring_status(Output_Type type, Service_T s, char *buf, int
                         snprintf(buf, buflen, "<span>Waiting</span>");
                 else
                         snprintf(buf, buflen, Color_white("Waiting"));
+        } else if (s->monitor & Monitor_WaitParent) {
+                if (type == HTML)
+                        snprintf(buf, buflen, "<span class='gray-text'>Wait parent</span>");
+                else
+                        snprintf(buf, buflen, Color_lightYellow("Wait parent"));
         } else if (s->monitor & Monitor_Init) {
                 if (type == HTML)
                         snprintf(buf, buflen, "<span class='blue-text'>Initializing</span>");
@@ -2402,7 +2407,7 @@ static char *get_monitoring_status(Output_Type type, Service_T s, char *buf, int
 static char *get_service_status(Output_Type type, Service_T s, char *buf, int buflen) {
         ASSERT(s);
         ASSERT(buf);
-        if (s->monitor == Monitor_Not || s->monitor & Monitor_Init) {
+        if ((s->monitor == Monitor_Not) || (s->monitor & Monitor_Init)) {
                 get_monitoring_status(type, s, buf, buflen);
         } else if (s->error == 0) {
                 if (type == HTML)

--- a/src/monit.h
+++ b/src/monit.h
@@ -261,10 +261,11 @@ typedef enum {
 
 
 typedef enum {
-        Monitor_Not     = 0x0,
-        Monitor_Yes     = 0x1,
-        Monitor_Init    = 0x2,
-        Monitor_Waiting = 0x4
+        Monitor_Not        = 0x0,
+        Monitor_Yes        = 0x1,
+        Monitor_Init       = 0x2,
+        Monitor_Waiting    = 0x4,
+        Monitor_WaitParent = 0x8,
 } __attribute__((__packed__)) Monitor_State;
 
 

--- a/src/state.c
+++ b/src/state.c
@@ -438,7 +438,7 @@ void State_save() {
                         memset(&state, 0, sizeof(state));
                         snprintf(state.name, sizeof(state.name), "%s", service->name);
                         state.type = service->type;
-                        state.monitor = service->monitor & ~Monitor_Waiting;
+                        state.monitor = service->monitor & ~(Monitor_Waiting | Monitor_WaitParent);
                         state.nstart = service->nstart;
                         state.ncycle = service->ncycle;
                         switch (service->type) {


### PR DESCRIPTION
Adam,

Please can you review this fix to https://github.com/Metaswitch/clearwater-infrastructure/issues/391?

The issue was that if monit reloads its state while a child is stopped because its parent is stopped, it never restarts.  This is because monit saves the fact that a child is stopped but not the fact that it's due to its parent.

I've fixed this by adding a WaitParent state that a process can be in.
*   When we stop processes because their parent is stopping (and we're not also unmonitoring), we set the WaitParent flag (in doDepend).
*   When we restart processes, we don't unmonitor/remonitor them, as the WaitParent flag does this for us (in controlService).
*   (Note that we don't preserve the WaitParent state over saving/reloading state, because we *do* preserve the Yes or Init states, which indicate that the process should still be monitored (in State_save).)
*   When deciding whether to poll (or skip) processes (in checkSkip), we reset state and check whether we're blocked behind our parent up front, rather than in a slightly odd order.  Also, we now handle processes inside checkSkip rather than in calling functions to ensure consistency.

There's no UT, but I've tested live
- starting a system from scratch using chef (everything comes up OK)
- upgrading packages (everything comes up OK)
- reloading monit while a parent process is failed, then recovering the parent (the child is restarted)
- stopping monit while a parent process is failed, recovering the parent and then restarting monit (the child is restarted).

Thanks,

Matt 