### PR TITLE
[Reviewer: Ellie] Add a log for getpgid returning EPERM

### DIFF
--- a/src/process/ProcessTree.c
+++ b/src/process/ProcessTree.c
@@ -346,9 +346,14 @@ pid_t ProcessTree_findProcess(Service_T s) {
                 pid_t pid = Util_getPid(s->path);
                 if (pid > 0) {
                         errno = 0;
-                        if (getpgid(pid) > -1 || errno == EPERM)
+                        if (getpgid(pid) > -1 || errno == EPERM){
+                                if (errno == EPERM) {
+                                        LogError("getpgid returned errno == EPERM for pid %d", pid);
+                                }
                                 return pid;
-                        DEBUG("'%s' process test failed [pid=%d] -- %s\n", s->name, pid, STRERROR);
+                        } else {
+                                DEBUG("'%s' process test failed [pid=%d] -- %s\n", s->name, pid, STRERROR);
+                        }
                 }
         }
         Util_resetInfo(s);


### PR DESCRIPTION
Previously we added a log in ProcessTree.c:325. This section of the code has now been commented out, so we won't hit that. However, i think we saw the same potential bug on a system.
The symptoms were that a process wasn't running, but had left the pidfile in place.
Monit was repeatedly reporting the log in https://github.com/Metaswitch/clearwater-monit/blob/14a3016f51f01e6cb800924b342b68ba3d6ebae2/src/validate.c#L1141  "Failed to get service data". 
To get to this log, we have to have returned a non-zero pid in ProcessTree_findProcess. As we do not have a cached pid, or a matchlist, we fall direct to the test on the pid in the pidfile, and at this point we have to have got either a pgid > -1 or errno=EPERM, or we would otherwise have returned 0 and deemed the process to be not running. 

As no process was running on the system with a pid matching the pidfile, we should be able to assume that getpgid would be returning -1 if working properly, which would cause us to return 0 at the end of the function, so we must be hitting the `errno==EPERM` side of the test. 
There's not much we can do here, so i'm adding the previously added log to this branch of the code.

There was a second problem, that despite failing to get service data repeatedly, the process was never restarted. This is because returning rv=State_failed in https://github.com/Metaswitch/clearwater-monit/blob/14a3016f51f01e6cb800924b342b68ba3d6ebae2/src/validate.c#L1102 only causes us to increase an error counter in https://github.com/Metaswitch/clearwater-monit/blob/14a3016f51f01e6cb800924b342b68ba3d6ebae2/src/validate.c#L1088, which is then ignored in https://github.com/Metaswitch/clearwater-monit/blob/d79468d4a6f5197d14bbaa377df41fc8ab78dc0e/src/monit.c#L574.

Potentially, we could add some code to restart a service if it falls into the 'failed to get service data' section of check_process, but for now i don't think it's worth the effort of working out how best to do it. If we see the log added here on a running system, or the same issue symptoms without this log, then we can revisit and attempt to work out the best next step.