### PR TITLE
Adding `ROOT` variable to Makefile

### DIFF
--- a/clearwater.mk
+++ b/clearwater.mk
@@ -1,3 +1,4 @@
+ROOT ?= $(PWD)
 PKG_COMPONENT := clearwater-monit
 PKG_MAJOR_VERSION := 5.18${DEB_VERSION_QUALIFIER}
 PKG_NAMES := clearwater-monit


### PR DESCRIPTION
Adding the `ROOT` variable to the Makefile so we can correctly reference licensing information.