### PR TITLE
[Reviewer: EM] Enable monit debug logs

### DIFF
--- a/debian/clearwater-monit.upstart
+++ b/debian/clearwater-monit.upstart
@@ -27,7 +27,7 @@ script
 
     /usr/share/clearwater/bin/issue-alarm "upstart" "4500.6"
 
-    exec /usr/bin/monit -I -c /etc/monit/monitrc $MONIT_OPTS
+    exec /usr/bin/monit -v -I -c /etc/monit/monitrc $MONIT_OPTS
 end script
 
 pre-stop exec /usr/bin/monit -c /etc/monit/monitrc quit


### PR DESCRIPTION
Enabling debug logging on Monit does not result in a huge amount of logging, but provides some very useful information for debugging.

This change enables debug logging on Monit by default. 