### PR TITLE
Warn when using monit without the '-g' group option

### DIFF
--- a/src/monit.c
+++ b/src/monit.c
@@ -21,7 +21,6 @@
  * You must obey the GNU Affero General Public License in all respects
  * for all of the code used other than OpenSSL.
  */
-#include <fcntl.h>
 
 #include "config.h"
 #include <locale.h>
@@ -407,7 +406,7 @@ static void do_action(char **args) {
                    IS(action, "stop")      ||
                    IS(action, "monitor")   ||
                    IS(action, "unmonitor") ||
-                   IS(action, "restart")) {           
+                   IS(action, "restart")) {
                 char *service = args[++optind];
                 if (Run.mygroup || service) {
                         int errors = 0;

--- a/src/monit.c
+++ b/src/monit.c
@@ -21,7 +21,7 @@
  * You must obey the GNU Affero General Public License in all respects
  * for all of the code used other than OpenSSL.
  */
-
+#include <fcntl.h>
 
 #include "config.h"
 #include <locale.h>
@@ -407,7 +407,7 @@ static void do_action(char **args) {
                    IS(action, "stop")      ||
                    IS(action, "monitor")   ||
                    IS(action, "unmonitor") ||
-                   IS(action, "restart")) {
+                   IS(action, "restart")) {           
                 char *service = args[++optind];
                 if (Run.mygroup || service) {
                         int errors = 0;
@@ -431,6 +431,7 @@ static void do_action(char **args) {
                                 for (Service_T s = servicelist; s; s = s->next)
                                         List_append(services, s->name);
                         } else {
+                                LogWarning("\nWARNING: 'monit %s <process>' only %ss the process specified. Related poll scripts will NOT be affected. Use 'monit %s -g <process group>' to be sure of %sing all related processes.\n\n", action, action, action, action);
                                 List_append(services, service);
                         }
                         errors = exist_daemon() ? (HttpClient_action(action, services) ? 0 : 1) : control_service_string(services, action);

--- a/src/monit.c
+++ b/src/monit.c
@@ -22,6 +22,7 @@
  * for all of the code used other than OpenSSL.
  */
 
+
 #include "config.h"
 #include <locale.h>
 


### PR DESCRIPTION
Hi Ellie, would you mind reviwing this monit-related fix?

The fix adds a warning log entry for when monit start/stop/restart/monitor/unmonitor is run without the '-g' option.

I have tested it by installing the clearwater-monit debian on one of our L3 test system nodes and running the commands in question.