### PR TITLE
[Reviewer: EM] Revert "Enable monit debug logs"

### DIFF
--- a/debian/clearwater-monit.upstart
+++ b/debian/clearwater-monit.upstart
@@ -27,7 +27,7 @@ script
 
     /usr/share/clearwater/bin/issue-alarm "upstart" "4500.6"
 
-    exec /usr/bin/monit -v -I -c /etc/monit/monitrc $MONIT_OPTS
+    exec /usr/bin/monit -I -c /etc/monit/monitrc $MONIT_OPTS
 end script
 
 pre-stop exec /usr/bin/monit -c /etc/monit/monitrc quit


### PR DESCRIPTION
Reverts Metaswitch/clearwater-monit#58

As discussed, the logs currently run risk of growing too large. We should re-revert this later if/when we decide to sort out the logging structures