### PR TITLE
NTP alarm

### DIFF
--- a/clearwater-monit.root/etc/monit/conf.d/ntp.monit
+++ b/clearwater-monit.root/etc/monit/conf.d/ntp.monit
@@ -1,47 +1,21 @@
 # @file ntp.monit
 #
-# Project Clearwater - IMS in the Cloud
-# Copyright (C) 2015  Metaswitch Networks Ltd
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or (at your
-# option) any later version, along with the "Special Exception" for use of
-# the program along with SSL, set forth below. This program is distributed
-# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE.  See the GNU General Public License for more
-# details. You should have received a copy of the GNU General Public
-# License along with this program.  If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# The author can be reached by email at clearwater@metaswitch.com or by
-# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
-#
-# Special Exception
-# Metaswitch Networks Ltd  grants you permission to copy, modify,
-# propagate, and distribute a work formed by combining OpenSSL with The
-# Software, or a work derivative of such a combination, even if such
-# copying, modification, propagation, or distribution would otherwise
-# violate the terms of the GPL. You must comply with the GPL in all
-# respects for all of the code used other than OpenSSL.
-# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
-# Project and licensed under the OpenSSL Licenses, or a work based on such
-# software and licensed under the OpenSSL Licenses.
-# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
-# under which the OpenSSL Project distributes the OpenSSL toolkit software,
-# as those licenses appear in the file LICENSE-OPENSSL.
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
 
-# Check the NTP process.
-
+# Check the NTP process and raise alarm.
 check process ntp_process
    matching "ntp" 
    group ntp
-   start program = "/bin/bash -c 'if [ -x /etc/init.d/ntp ]; then /usr/share/clearwater/bin/issue-alarm monit 5000; /etc/init.d/ntp start; else systemctl enable ntpd && systemctl start ntpd; fi'"
-   stop program = "/bin/bash -c 'if [ -x /etc/init.d/ntp ]; then /usr/share/clearwater/bin/issue-alarm monit 5000; /etc/init.d/ntp stop; else systemctl disable ntpd && systemctl stop ntpd; fi'"
+   start program = "/bin/bash -c 'if [ -x /etc/init.d/ntp ]; then /usr/share/clearwater/bin/issue-alarm monit 13500.3; /etc/init.d/ntp start; else systemctl enable ntpd && systemctl start ntpd; fi'"
+   stop program = "/bin/bash -c 'if [ -x /etc/init.d/ntp ]; then /usr/share/clearwater/bin/issue-alarm monit 13500.3; /etc/init.d/ntp stop; else systemctl disable ntpd && systemctl stop ntpd; fi'"
 
 # clear any alarms if the process has been running long enough.
-check program rogers_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-ntp-uptime
+check program ntp_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-ntp-uptime
   group ntp
   depends on ntp_process
   every 3 cycles

--- a/clearwater-monit.root/etc/monit/conf.d/ntp.monit
+++ b/clearwater-monit.root/etc/monit/conf.d/ntp.monit
@@ -37,5 +37,12 @@
 check process ntp_process
    matching "ntp" 
    group ntp
-   start program = "/bin/bash -c 'if [ -x /etc/init.d/ntp ]; then /etc/init.d/ntp start; else systemctl enable ntpd && systemctl start ntpd; fi'"
-   stop program = "/bin/bash -c 'if [ -x /etc/init.d/ntp ]; then /etc/init.d/ntp stop; else systemctl disable ntpd && systemctl stop ntpd; fi'"
+   start program = "/bin/bash -c 'if [ -x /etc/init.d/ntp ]; then /usr/share/clearwater/bin/issue-alarm monit 5000; /etc/init.d/ntp start; else systemctl enable ntpd && systemctl start ntpd; fi'"
+   stop program = "/bin/bash -c 'if [ -x /etc/init.d/ntp ]; then /usr/share/clearwater/bin/issue-alarm monit 5000; /etc/init.d/ntp stop; else systemctl disable ntpd && systemctl stop ntpd; fi'"
+
+# clear any alarms if the process has been running long enough.
+check program rogers_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-ntp-uptime
+  group ntp
+  depends on ntp_process
+  every 3 cycles
+  if status != 0 then alert

--- a/clearwater-monit.root/usr/share/clearwater/infrastructure/alarms/ntp_alarms.json
+++ b/clearwater-monit.root/usr/share/clearwater/infrastructure/alarms/ntp_alarms.json
@@ -1,0 +1,27 @@
+{
+    "alarms": [
+        {
+            "index": 5000,
+            "cause": "SOFTWARE_ERROR",
+            "name": "NTP_PROCESS_FAIL",
+            "levels": [
+                {
+                    "severity": "CLEARED",
+                    "details": "The NTP process has been restored to normal operation.",
+                    "description": "NTP: Process failure cleared.",
+                    "cause": "The NTP process has been restored to normal operation. The previously issued alarm has been cleared.",
+                    "effect": "Normal process monitoring operations have been restored.",
+                    "action": "No action."
+                },
+                {
+                    "severity": "WARNING",
+                    "details": "Upstart has detected that the NTP process has failed. A restart will automatically be attempted. If this alarm does not clear, an unrecoverable failure may have occurred.",
+                    "description": "NTP: Process failure.",
+                    "cause": "The system has detected that the NTP process has failed.",
+                    "effect": "Constant monitoring of processes has stopped. Process failures will not be detected until Monit is restored to service and the alarm is cleared.",
+                    "action": "Monitor for this alarm to clear. If it does not clear then contact your support representative."
+                }
+            ]
+        }
+    ]
+}

--- a/clearwater-monit.root/usr/share/clearwater/infrastructure/alarms/ntp_alarms.json
+++ b/clearwater-monit.root/usr/share/clearwater/infrastructure/alarms/ntp_alarms.json
@@ -1,7 +1,7 @@
 {
     "alarms": [
         {
-            "index": 5000,
+            "index": 13500,
             "cause": "SOFTWARE_ERROR",
             "name": "NTP_PROCESS_FAIL",
             "levels": [

--- a/clearwater-monit.root/usr/share/clearwater/infrastructure/monit_uptime/check-ntp-uptime
+++ b/clearwater-monit.root/usr/share/clearwater/infrastructure/monit_uptime/check-ntp-uptime
@@ -12,4 +12,4 @@
 # Monit 5.8.1 does not support passing arguments to check program scripts.
 # check-uptime provides common uptime-checking code. This wrapper script
 # uses it, and can be called with no arguments.
-/usr/share/clearwater/bin/check-uptime /var/run/rogers/ntp.pid ntp 5000
+/usr/share/clearwater/bin/check-uptime /var/run/rogers/ntp.pid ntp 13500.1

--- a/clearwater-monit.root/usr/share/clearwater/infrastructure/monit_uptime/check-ntp-uptime
+++ b/clearwater-monit.root/usr/share/clearwater/infrastructure/monit_uptime/check-ntp-uptime
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# @file check-ntp-uptime
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+# Monit 5.8.1 does not support passing arguments to check program scripts.
+# check-uptime provides common uptime-checking code. This wrapper script
+# uses it, and can be called with no arguments.
+/usr/share/clearwater/bin/check-uptime /var/run/rogers/ntp.pid ntp 5000


### PR DESCRIPTION
Similar to sprout alarm. Define an alarm `13500` and raise it with `.3` during checking process, and clear it after three cycles with `.1`.
Alarm number range `13500-13699` reserved in https://github.com/Metaswitch/cpp-common/pull/731

Going to live test by using `SNMP trap d` to print the output of alarm agent.

Another issue is to check if NTP is talking to its server okay - left for future fix